### PR TITLE
taking B * gain outside of loop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: activityCounts
 Type: Package
 Title: Generate ActiLife Counts
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(
   person("Ruben", "Brondeel", role = "aut"),
   person("Javad", "Rahimipour Anaraki", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ RoxygenNote: 6.1.1
 Suggests: 
     knitr,
     rmarkdown,
-    ggplot2
+    ggplot2,
+    testthat (>= 3.0.0)
 VignetteBuilder: knitr
 Imports: 
     seewave,
@@ -33,3 +34,4 @@ Imports:
     tibble,
     lubridate,
     magrittr
+Config/testthat/edition: 3

--- a/R/counts.R
+++ b/R/counts.R
@@ -139,6 +139,7 @@ counts = function(data,
   integN = 10
   gain = 0.965
   out = NULL
+  B = B * gain
 
   for (i in 1:3) {
     if (hertz > sf) {
@@ -159,7 +160,6 @@ counts = function(data,
       datab = filtfilt(AB$b, AB$a, data[, i])
     }
 
-    B = B * gain
     fx8up = filter(B, A, datab)
     fx8 = pptrunc(fx8up[seq(1, length(fx8up), 3)], peakThreshold)
     out = cbind(out, runsum(floor(trunc(

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(activityCounts)
+
+test_check("activityCounts")

--- a/tests/testthat/test-reordering.R
+++ b/tests/testthat/test-reordering.R
@@ -1,0 +1,31 @@
+testthat::test_that("Reordering columns gives the same result", {
+
+
+  #' Here we use the correct columns and use the time column
+  sampleXYZ_counts <- counts(
+    data = activityCounts::sampleXYZ, hertz = 100,
+    x_axis = 2,y_axis = 3, z_axis = 4, time_column = 1)
+
+  #' Here simply reorder the columns so Y is first
+  data2 = sampleXYZ
+  data2 = data2[, c("Time", paste0("accelerometer_", c("Z", "Y", "X")))]
+  #' when we calculate counts, this lines up correctly (x is 3rd axis, y is 2nd)
+  sampleXYZ_counts2 <- counts(data = data2, hertz = 100,
+                              x_axis = 4,y_axis = 3,z_axis = 2, time_column = 1)
+  head(sampleXYZ_counts2)
+  #' they are equal
+  testthat::expect_equal(sampleXYZ_counts, sampleXYZ_counts2)
+
+  #' If we pass in the original data, but "incorrectly" specify the 3rd column is X
+  sampleXYZ_counts3 <- counts(data = sampleXYZ, hertz = 100,
+                              x_axis = 3, y_axis = 2,z_axis = 4, time_column = 1)
+  #' We see these are different, which is understandable because "x" means different things
+  testthat::expect_failure(
+    testthat::expect_equal(sampleXYZ_counts, sampleXYZ_counts3)
+  )
+  #' If we reorder the columns it still persists, which means the method is
+  #' not agnostic to the order of the columns
+  sampleXYZ_counts3 = sampleXYZ_counts3[c("Time", "y", "x", "z")]
+  colnames(sampleXYZ_counts3) = c("Time", "x", "y", "z")
+  testthat::expect_equal(sampleXYZ_counts, sampleXYZ_counts3)
+})


### PR DESCRIPTION
This should fix the issue #5, which makes sure the order of the columns doesn't affect the results and the `Y`/`Z` columns use the same `B*gain` as `X` 